### PR TITLE
Add curl

### DIFF
--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -30,7 +30,7 @@ echo ""
 read -n1 -r -p "Nginx is ready to be installed, press any key to continue..."
 
 # Dependencies
-apt-get install build-essential ca-certificates wget libpcre3 libpcre3-dev autoconf unzip automake libtool tar git libssl-dev -y
+apt-get install curl build-essential ca-certificates wget libpcre3 libpcre3-dev autoconf unzip automake libtool tar git libssl-dev -y
 
 # LibreSSL
 if [[ "$LIBRESSL" = 'y' ]]; then


### PR DESCRIPTION
~~J'avais besoins du module RTMP pour un de mes projets, j'ai donc adapté ton script.
A toi de voir si tu souhaites faire cette modification, bien que RTMP ne soit utilisé que dans de très rare cas puisque ce n'est pas utile pour le web, mais pour du streaming twitch par exemple.~~

Ceci étant dit, j'ai également ajouté curl à la liste des apt-get install puisque celui-ci n'était pas installé sur mon système mais était utilisé dans le script.