### PR TITLE
Map module

### DIFF
--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -137,7 +137,6 @@ NGINX_MODULES="--without-http_ssi_module \
 --without-http_scgi_module \
 --without-http_uwsgi_module \
 --without-http_geo_module \
---without-http_map_module \
 --without-http_split_clients_module \
 --without-http_memcached_module \
 --without-http_empty_gif_module \

--- a/src/nginx-brotli.sh
+++ b/src/nginx-brotli.sh
@@ -33,7 +33,6 @@ cd nginx-${NGINX_VER}
 	--without-http_scgi_module \
 	--without-http_uwsgi_module \
 	--without-http_geo_module \
-	--without-http_map_module \
 	--without-http_split_clients_module \
 	--without-http_memcached_module \
 	--without-http_empty_gif_module \

--- a/src/nginx-libressl.sh
+++ b/src/nginx-libressl.sh
@@ -36,7 +36,6 @@ sed -i -e "s/install_sw/install/g" auto/lib/openssl/make
 	--without-http_scgi_module \
 	--without-http_uwsgi_module \
 	--without-http_geo_module \
-	--without-http_map_module \
 	--without-http_split_clients_module \
 	--without-http_memcached_module \
 	--without-http_empty_gif_module \

--- a/src/nginx-pagespeed.sh
+++ b/src/nginx-pagespeed.sh
@@ -32,7 +32,6 @@ cd nginx-${NGINX_VER}
 	--without-http_scgi_module \
 	--without-http_uwsgi_module \
 	--without-http_geo_module \
-	--without-http_map_module \
 	--without-http_split_clients_module \
 	--without-http_memcached_module \
 	--without-http_empty_gif_module \

--- a/src/nginx.sh
+++ b/src/nginx.sh
@@ -22,7 +22,6 @@ cd nginx-${NGINX_VER}
 	--without-http_scgi_module \
 	--without-http_uwsgi_module \
 	--without-http_geo_module \
-	--without-http_map_module \
 	--without-http_split_clients_module \
 	--without-http_memcached_module \
 	--without-http_empty_gif_module \


### PR DESCRIPTION
You should not delete Map Module.
You need it in order to use th 6G PerishablePress rules for NGinx
http://blog.stephane-huc.net/post/6G-PerishablePress-pour-nginx