### PR TITLE
Update nginx to 1.11.13

### DIFF
--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -13,7 +13,7 @@ if [[ "$EUID" -ne 0 ]]; then
 fi
 
 # Variables
-NGINX_VER=1.11.12
+NGINX_VER=1.11.13
 LIBRESSL_VER=2.5.2
 
 OPENSSL_VER=1.1.0e


### PR DESCRIPTION
Changes with nginx 1.11.13  (04 Apr 2017)

    *) Feature: the "http_429" parameter of the "proxy_next_upstream",
       "fastcgi_next_upstream", "scgi_next_upstream", and
       "uwsgi_next_upstream" directives.
       Thanks to Piotr Sikora.

    *) Bugfix: in memory allocation error handling.

    *) Bugfix: requests might hang when using the "sendfile" and
       "timer_resolution" directives on Linux.

    *) Bugfix: requests might hang when using the "sendfile" and "aio_write"
       directives with subrequests.

    *) Bugfix: in the ngx_http_v2_module.
       Thanks to Piotr Sikora.

    *) Bugfix: a segmentation fault might occur in a worker process when
       using HTTP/2.

    *) Bugfix: requests might hang when using the "limit_rate",
       "sendfile_max_chunk", "limit_req" directives, or the $r->sleep()
       embedded perl method with subrequests.

    *) Bugfix: in the ngx_http_slice_module.