### PR TITLE
Update nginx-autoinstall.sh

### DIFF
--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -114,7 +114,7 @@ case $OPTION in
 			[ -e scripts/format_binary_url.sh ] && psol_url=$(scripts/format_binary_url.sh PSOL_BINARY_URL)
 			wget ${psol_url} 2>> /tmp/nginx-autoinstall-error.log 1>> /tmp/nginx-autoinstall-output.log
 			tar -xzvf $(basename ${psol_url}) 2>> /tmp/nginx-autoinstall-error.log 1>> /tmp/nginx-autoinstall-output.log
-			rm ${NPS_VER}-x64.tar.gz
+			rm $(basename ${psol_url})
 
 			if [ $? -eq 0 ]; then
 			echo -ne "       Downloading ngx_pagespeed      [${CGREEN}OK${CEND}]\r"


### PR DESCRIPTION
Sur une machine en 32bits ou un arm, il telecharge le PSOL en version 32bits qui ne s'appelle pas "-x64" mais "-ia32"

Donc il ne trouve pas le fichier et le script s’interrompt
Modification testé sur un Raspberry et fonctionne