### PR TITLE
Update nginx to 1.13.0

### DIFF
--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -13,7 +13,7 @@ if [[ "$EUID" -ne 0 ]]; then
 fi
 
 # Variables
-NGINX_VER=1.12.0
+NGINX_VER=1.13.0
 LIBRESSL_VER=2.5.3
 OPENSSL_VER=1.1.0e
 NPS_VER=1.12.34.2


### PR DESCRIPTION
Changes with nginx 1.13.0                                        25 Apr 2017

    *) Change: SSL renegotiation is now allowed on backend connections.

    *) Feature: the "rcvbuf" and "sndbuf" parameters of the "listen"
       directives of the mail proxy and stream modules.

    *) Feature: the "return" and "error_page" directives can now be used to
       return 308 redirections.
       Thanks to Simon Leblanc.

    *) Feature: the "TLSv1.3" parameter of the "ssl_protocols" directive.

    *) Feature: when logging signals nginx now logs PID of the process which
       sent the signal.

    *) Bugfix: in memory allocation error handling.

    *) Bugfix: if a server in the stream module listened on a wildcard
       address, the source address of a response UDP datagram could differ
       from the original datagram destination address.