### PR TITLE
Update nginx to 1.13.2

### DIFF
--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -13,7 +13,7 @@ if [[ "$EUID" -ne 0 ]]; then
 fi
 
 # Variables
-NGINX_VER=1.13.1
+NGINX_VER=1.13.2
 LIBRESSL_VER=2.5.4
 OPENSSL_VER=1.1.0f
 NPS_VER=1.12.34.2


### PR DESCRIPTION
Changes with nginx 1.13.2                                        27 Jun 2017

    *) Change: nginx now returns 200 instead of 416 when a range starting
       with 0 is requested from an empty file.

    *) Feature: the "add_trailer" directive.
       Thanks to Piotr Sikora.

    *) Bugfix: nginx could not be built on Cygwin and NetBSD; the bug had
       appeared in 1.13.0.

    *) Bugfix: nginx could not be built under MSYS2 / MinGW 64-bit.
       Thanks to Orgad Shaneh.

    *) Bugfix: a segmentation fault might occur in a worker process when
       using SSI with many includes and proxy_pass with variables.

    *) Bugfix: in the ngx_http_v2_module.
       Thanks to Piotr Sikora.
Source: https://nginx.org/en/CHANGES