### PR TITLE
Block nginx installation from APT using pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Compile and install Nginx from source with optionnal modules.
 - [Custom nginx.conf](https://github.com/Angristan/nginx-autoinstall/blob/master/conf/nginx.conf) (default does not work)
 - [Init script for systemd](https://github.com/Angristan/nginx-autoinstall/blob/master/conf/nginx.service) (not provided by default)
 - [Logrotate conf](https://github.com/Angristan/nginx-autoinstall/blob/master/conf/nginx-logrotate) (not provided by default)
+- Block Nginx installation from APT using pinning, to prevent conflicts
 
 ### Optional modules/features
 

--- a/conf/apt-nginx
+++ b/conf/apt-nginx
@@ -1,0 +1,3 @@
+Package: nginx*
+Pin: release *
+Pin-Priority: -1

--- a/conf/apt-nginx
+++ b/conf/apt-nginx
@@ -1,3 +1,0 @@
-Package: nginx*
-Pin: release *
-Pin-Priority: -1

--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -663,7 +663,7 @@ case $OPTION in
 			echo -ne "       Removing log files             [${CGREEN}OK${CEND}]\r"
 			echo -ne "\n"
 		fi
-		
+
 		if [[ $(lsb_release -si) == "Debian" ]] || [[ $(lsb_release -si) == "Ubuntu" ]]
 		then
 			echo -ne "       Unblock nginx package from APT [..]\r"

--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -597,7 +597,7 @@ case $OPTION in
 		then
 			echo -ne "       Blocking nginx from APT           [..]\r"
 			cd /etc/apt/preferences.d/
-			wget https://raw.githubusercontent.com/Angristan/nginx-autoinstall/master/conf/apt-nginx -O nginx-block >> /tmp/nginx-autoinstall.log 2>&1
+			echo -e "Package: nginx*\nPin: release *\nPin-Priority: -1" > nginx-block
 			echo -ne "       Blocking nginx from APT           [${CGREEN}OK${CEND}]\r"
 			echo -ne "\n"
 		fi

--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -595,10 +595,10 @@ case $OPTION in
 		
 		if [[ $(lsb_release -si) == "Debian" ]] || [[ $(lsb_release -si) == "Ubuntu" ]]
 		then
-			echo -ne "       Blocking nginx from APT           [..]\r"
+			echo -ne "       Blocking nginx from APT        [..]\r"
 			cd /etc/apt/preferences.d/
 			echo -e "Package: nginx*\nPin: release *\nPin-Priority: -1" > nginx-block
-			echo -ne "       Blocking nginx from APT           [${CGREEN}OK${CEND}]\r"
+			echo -ne "       Blocking nginx from APT        [${CGREEN}OK${CEND}]\r"
 			echo -ne "\n"
 		fi
 
@@ -666,9 +666,9 @@ case $OPTION in
 		
 		if [[ $(lsb_release -si) == "Debian" ]] || [[ $(lsb_release -si) == "Ubuntu" ]]
 		then
-			echo -ne "       Unblock nginx package from APT             [..]\r"
+			echo -ne "       Unblock nginx package from APT [..]\r"
 			rm /etc/apt/preferences.d/nginx-block >> /tmp/nginx-autoinstall.log 2>&1
-			echo -ne "       Unblock nginx package from APT             [${CGREEN}OK${CEND}]\r"
+			echo -ne "       Unblock nginx package from APT [${CGREEN}OK${CEND}]\r"
 			echo -ne "\n"
 		fi
 

--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -595,7 +595,11 @@ case $OPTION in
 		
 		if [[ $(lsb_release -si) == "Debian" ]] || [[ $(lsb_release -si) == "Ubuntu" ]]
 		then
-			wget https://raw.githubusercontent.com/Angristan/nginx-autoinstall/master/conf/apt-nginx
+			echo -ne "       Blocking nginx from APT           [..]\r"
+			cd /etc/apt/preferences.d/
+			wget https://raw.githubusercontent.com/Angristan/nginx-autoinstall/master/conf/apt-nginx -O nginx-block >> /tmp/nginx-autoinstall.log 2>&1
+			echo -ne "       Blocking nginx from APT           [${CGREEN}OK${CEND}]\r"
+			echo -ne "\n"
 		fi
 
 		# Removing temporary Nginx and modules files
@@ -657,6 +661,14 @@ case $OPTION in
 			echo -ne "       Removing log files             [..]\r"
 			rm -r /var/log/nginx >> /tmp/nginx-autoinstall.log 2>&1
 			echo -ne "       Removing log files             [${CGREEN}OK${CEND}]\r"
+			echo -ne "\n"
+		fi
+		
+		if [[ $(lsb_release -si) == "Debian" ]] || [[ $(lsb_release -si) == "Ubuntu" ]]
+		then
+			echo -ne "       Unblock nginx package from APT             [..]\r"
+			rm /etc/apt/preferences.d/nginx-block >> /tmp/nginx-autoinstall.log 2>&1
+			echo -ne "       Unblock nginx package from APT             [${CGREEN}OK${CEND}]\r"
 			echo -ne "\n"
 		fi
 

--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -592,6 +592,11 @@ case $OPTION in
 			echo ""
 			exit 1
 		fi
+		
+		if [[ $(lsb_release -si) == "Debian" ]] || [[ $(lsb_release -si) == "Ubuntu" ]]
+		then
+			wget https://raw.githubusercontent.com/Angristan/nginx-autoinstall/master/conf/apt-nginx
+		fi
 
 		# Removing temporary Nginx and modules files
 		echo -ne "       Removing Nginx files           [..]\r"


### PR DESCRIPTION
Just had a problem in the afternoon with a script that had "apt -y install nginx-full" in it, so here is a little security to prevent that :)