### PR TITLE
Add support for Nginx virtual host traffic status module

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Compile and install Nginx from source with optional modules.
 * [ngx_http_geoip2_module](https://github.com/leev/ngx_http_geoip2_module) with [libmaxminddb](https://github.com/maxmind/libmaxminddb) and [GeoLite2 databases](https://dev.maxmind.com/geoip/geoip2/geolite2/)
 * [ngx_cache_purge](https://github.com/FRiCKLE/ngx_cache_purge) (Purge content from FastCGI, proxy, SCGI and uWSGI caches)
 * [ngx-fancyindex](https://github.com/aperezdc/ngx-fancyindex) (Fancy indexes module)
+* [nginx-dav-ext-module](https://github.com/arut/nginx-dav-ext-module) (nginx WebDAV PROPFIND,OPTIONS,LOCK,UNLOCK support)
+* [nginx-module-vts](https://github.com/vozlt/nginx-module-vts) (Nginx virtual host traffic status module )
+  - See install instructions: [nginx-module-vts#installation](https://github.com/vozlt/nginx-module-vts#installation) 
 
 ## Install Nginx
 

--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -26,6 +26,7 @@ if [[ "$HEADLESS" == "y" ]]; then
 	FANCYINDEX=${FANCYINDEX:-n}
 	CACHEPURGE=${CACHEPURGE:-n}
 	WEBDAV=${WEBDAV:-n}
+	VTS=${VTS:-n}
 	SSL=${SSL:-1}
 	RM_CONF=${RM_CONF:-y}
 	RM_LOGS=${RM_LOGS:-y}
@@ -103,6 +104,9 @@ case $OPTION in
 			done
 			while [[ $WEBDAV != "y" && $WEBDAV != "n" ]]; do
 				read -p "       nginx WebDAV [y/n]: " -e WEBDAV
+			done
+			while [[ $VTS != "y" && $VTS != "n" ]]; do
+				read -p "       nginx VTS [y/n]: " -e VTS
 			done
 			echo ""
 			echo "Choose your OpenSSL implementation :"
@@ -309,6 +313,11 @@ case $OPTION in
 		if [[ "$WEBDAV" = 'y' ]]; then
 			git clone --quiet https://github.com/arut/nginx-dav-ext-module.git /usr/local/src/nginx/modules/nginx-dav-ext-module
 			NGINX_MODULES=$(echo "$NGINX_MODULES"; echo --with-http_dav_module --add-module=/usr/local/src/nginx/modules/nginx-dav-ext-module)
+		fi
+		
+		if [[ "$VTS" = 'y' ]]; then
+			git clone --quiet https://github.com/vozlt/nginx-module-vts.git /usr/local/src/nginx/modules/nginx-module-vts
+			NGINX_MODULES=$(echo "$NGINX_MODULES"; echo --add-module=/usr/local/src/nginx/modules/nginx-module-vts)
 		fi
 
 		./configure $NGINX_OPTIONS $NGINX_MODULES


### PR DESCRIPTION
Add support for [Nginx virtual host traffic status module](https://github.com/vozlt/nginx-module-vts#installation)

![screenshot](https://cloud.githubusercontent.com/assets/3648408/23890539/a4c0de18-08d5-11e7-9a8b-448662454854.png)

Just found this module. Works great. 

Tested on two Debian 9 servers.

To enable, see installation: [github.com/vozlt/nginx-module-vts#installation](https://github.com/vozlt/nginx-module-vts#installation)