### PR TITLE
Fix shellcheck SC1090

### DIFF
--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -478,6 +478,7 @@ case $OPTION in
 		apt-get install -y golang
 		# Rust is not packaged so that's the only way...
 		curl -sSf https://sh.rustup.rs | sh -s -- -y
+		# shellcheck disable=SC1090
 		source "$HOME/.cargo/env"
 
 		cd /usr/local/src/nginx/nginx-${NGINX_VER} || exit 1


### PR DESCRIPTION

Can't follow non-constant source. Use a directive to specify location.