### PR TITLE
Reload systemctl

### DIFF
--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -574,6 +574,9 @@ case $OPTION in
 		/lib/systemd/system/nginx.service \
 		/etc/systemd/system/multi-user.target.wants/nginx.service
 
+		# Reload systemctl
+		systemctl daemon-reload
+
 	# Remove conf files
 	if [[ $RM_CONF == 'y' ]]; then
 		rm -r /etc/nginx/


### PR DESCRIPTION
Reload systemctl after uninstall.

Uninstall without results in warning:

`Warning: The unit file, source configuration file or drop-ins of nginx.service changed on disk. Run 'systemctl daemon-reload' to reload units.`