### PR TITLE
Add http3 support to newest nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The script might work on ARM-based architectures, but it's only being regularly 
 
 - [LibreSSL from source](http://www.libressl.org/) (CHACHA20, ALPN for HTTP/2, X25519, P-521)
 - [OpenSSL from source](https://www.openssl.org/) (TLS 1.3, CHACHA20, ALPN for HTTP/2, X25519, P-521)
-- [Cloudflare's patch for HTTP/3](https://blog.cloudflare.com/experiment-with-http-3-using-nginx-and-quiche/) with [Quiche](https://github.com/cloudflare/quiche) and [BoringSSL](https://github.com/google/boringssl). (⚠️ the patch [doesn't work for versions > 1.19.6](https://github.com/cloudflare/quiche/issues/859).)
+- [Cloudflare's patch for HTTP/3](https://blog.cloudflare.com/experiment-with-http-3-using-nginx-and-quiche/) with [Quiche](https://github.com/cloudflare/quiche) and [BoringSSL](https://github.com/google/boringssl).
 - [Cloudflare's TLS Dynamic Record Resizing patch](https://blog.cloudflare.com/optimizing-tls-over-tcp-to-reduce-latency/) maintained by [nginx-modules](https://github.com/nginx-modules/ngx_http_tls_dyn_size).
 - [Cloudflare's HTTP/2 HPACK encoding patch](https://blog.cloudflare.com/hpack-the-silent-killer-feature-of-http-2/) ([original patch](https://github.com/cloudflare/sslconfig/blob/master/patches/nginx_1.13.1_http2_hpack.patch), [fixed patch](https://github.com/hakasenyang/openssl-patch/blob/master/nginx_hpack_push_1.15.3.patch))
 - [ngx_pagespeed](https://github.com/pagespeed/ngx_pagespeed): Google performance module

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The script might work on ARM-based architectures, but it's only being regularly 
 
 - [LibreSSL from source](http://www.libressl.org/) (CHACHA20, ALPN for HTTP/2, X25519, P-521)
 - [OpenSSL from source](https://www.openssl.org/) (TLS 1.3, CHACHA20, ALPN for HTTP/2, X25519, P-521)
-- [Cloudflare's patch for HTTP/3](https://blog.cloudflare.com/experiment-with-http-3-using-nginx-and-quiche/) with [Quiche](https://github.com/cloudflare/quiche) and [BoringSSL](https://github.com/google/boringssl).
+- [Cloudflare's patch for HTTP/3](https://blog.cloudflare.com/experiment-with-http-3-using-nginx-and-quiche/) with [Quiche](https://github.com/cloudflare/quiche) and [BoringSSL](https://github.com/google/boringssl).  
 - [Cloudflare's TLS Dynamic Record Resizing patch](https://blog.cloudflare.com/optimizing-tls-over-tcp-to-reduce-latency/) maintained by [nginx-modules](https://github.com/nginx-modules/ngx_http_tls_dyn_size).
 - [Cloudflare's HTTP/2 HPACK encoding patch](https://blog.cloudflare.com/hpack-the-silent-killer-feature-of-http-2/) ([original patch](https://github.com/cloudflare/sslconfig/blob/master/patches/nginx_1.13.1_http2_hpack.patch), [fixed patch](https://github.com/hakasenyang/openssl-patch/blob/master/nginx_hpack_push_1.15.3.patch))
 - [ngx_pagespeed](https://github.com/pagespeed/ngx_pagespeed): Google performance module

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The script might work on ARM-based architectures, but it's only being regularly 
 
 - [LibreSSL from source](http://www.libressl.org/) (CHACHA20, ALPN for HTTP/2, X25519, P-521)
 - [OpenSSL from source](https://www.openssl.org/) (TLS 1.3, CHACHA20, ALPN for HTTP/2, X25519, P-521)
-- [Cloudflare's patch for HTTP/3](https://blog.cloudflare.com/experiment-with-http-3-using-nginx-and-quiche/) with [Quiche](https://github.com/cloudflare/quiche) and [BoringSSL](https://github.com/google/boringssl).  
+- [Cloudflare's patch for HTTP/3](https://blog.cloudflare.com/experiment-with-http-3-using-nginx-and-quiche/) with [Quiche](https://github.com/cloudflare/quiche) and [BoringSSL](https://github.com/google/boringssl).
 - [Cloudflare's TLS Dynamic Record Resizing patch](https://blog.cloudflare.com/optimizing-tls-over-tcp-to-reduce-latency/) maintained by [nginx-modules](https://github.com/nginx-modules/ngx_http_tls_dyn_size).
 - [Cloudflare's HTTP/2 HPACK encoding patch](https://blog.cloudflare.com/hpack-the-silent-killer-feature-of-http-2/) ([original patch](https://github.com/cloudflare/sslconfig/blob/master/patches/nginx_1.13.1_http2_hpack.patch), [fixed patch](https://github.com/hakasenyang/openssl-patch/blob/master/nginx_hpack_push_1.15.3.patch))
 - [ngx_pagespeed](https://github.com/pagespeed/ngx_pagespeed): Google performance module

--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -520,7 +520,7 @@ case $OPTION in
 		# Apply actual patch
 		patch -p01 </usr/local/src/nginx/modules/quiche/extras/nginx/nginx-1.16.patch
 
-		# Apply patch for nginx > 1.19.7
+		# Apply patch for nginx > 1.19.7 (source: https://github.com/cloudflare/quiche/issues/936#issuecomment-857618081)
 		wget https://raw.githubusercontent.com/angristan/nginx-autoinstall/master/patches/nginx-http3-1.19.7.patch -O nginx-http3.patch
 		patch -p01 <nginx-http3.patch
 

--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -99,7 +99,7 @@ case $OPTION in
 		echo ""
 		echo "Modules to install :"
 		while [[ $HTTP3 != "y" && $HTTP3 != "n" ]]; do
-			read -rp "       HTTP/3 (⚠️ Patch by Cloudflare for versions <= 1.19.7, will install BoringSSL, Quiche, Rust and Go) [y/n]: " -e -i n HTTP3
+			read -rp "       HTTP/3 (⚠️ Patch by Cloudflare , will install BoringSSL, Quiche, Rust and Go) [y/n]: " -e -i n HTTP3
 		done
 		while [[ $TLSDYN != "y" && $TLSDYN != "n" ]]; do
 			read -rp "       Cloudflare's TLS Dynamic Record Resizing patch [y/n]: " -e -i n TLSDYN
@@ -510,7 +510,6 @@ case $OPTION in
 	if [[ $HTTP3 == 'y' ]]; then
 		cd /usr/local/src/nginx/modules || exit 1
 		git clone --depth 1 --recursive https://github.com/cloudflare/quiche
-		git clone https://github.com/patrikjuvonen/docker-nginx-http3.git
 		# Dependencies for BoringSSL and Quiche
 		apt-get install -y golang
 		# Rust is not packaged so that's the only way...
@@ -520,7 +519,10 @@ case $OPTION in
 		cd /usr/local/src/nginx/nginx-${NGINX_VER} || exit 1
 		# Apply actual patch
 		patch -p01 </usr/local/src/nginx/modules/quiche/extras/nginx/nginx-1.16.patch
-		patch -p01 </usr/local/src/nginx/modules/docker-nginx-http3/nginx-1.19.7.patch
+
+		# Apply patch for nginx > 1.19.7
+		wget https://raw.githubusercontent.com/angristan/nginx-autoinstall/master/patches/nginx-http3-1.19.7.patch -O nginx-http3.patch
+		patch -p01 <nginx-http3.patch
 
 		NGINX_OPTIONS=$(
 			echo "$NGINX_OPTIONS"

--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -510,6 +510,7 @@ case $OPTION in
 	if [[ $HTTP3 == 'y' ]]; then
 		cd /usr/local/src/nginx/modules || exit 1
 		git clone --depth 1 --recursive https://github.com/cloudflare/quiche
+		git clone https://github.com/patrikjuvonen/docker-nginx-http3.git
 		# Dependencies for BoringSSL and Quiche
 		apt-get install -y golang
 		# Rust is not packaged so that's the only way...
@@ -519,6 +520,7 @@ case $OPTION in
 		cd /usr/local/src/nginx/nginx-${NGINX_VER} || exit 1
 		# Apply actual patch
 		patch -p01 </usr/local/src/nginx/modules/quiche/extras/nginx/nginx-1.16.patch
+		patch -p01 </usr/local/src/nginx/modules/docker-nginx-http3/nginx-1.19.7.patch
 
 		NGINX_OPTIONS=$(
 			echo "$NGINX_OPTIONS"

--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -99,7 +99,7 @@ case $OPTION in
 		echo ""
 		echo "Modules to install :"
 		while [[ $HTTP3 != "y" && $HTTP3 != "n" ]]; do
-			read -rp "       HTTP/3 (⚠️ Patch by Cloudflare , will install BoringSSL, Quiche, Rust and Go) [y/n]: " -e -i n HTTP3
+			read -rp "       HTTP/3 (⚠️ Patch by Cloudflare, will install BoringSSL, Quiche, Rust and Go) [y/n]: " -e -i n HTTP3
 		done
 		while [[ $TLSDYN != "y" && $TLSDYN != "n" ]]; do
 			read -rp "       Cloudflare's TLS Dynamic Record Resizing patch [y/n]: " -e -i n TLSDYN

--- a/patches/nginx-http3-1.19.7.patch
+++ b/patches/nginx-http3-1.19.7.patch
@@ -1,0 +1,34 @@
+diff --git a/src/http/ngx_http_request.c b/src/http/ngx_http_request.c
+index d9d28cf..0c6dbba 100644
+--- a/src/http/ngx_http_request.c
++++ b/src/http/ngx_http_request.c
+@@ -361,7 +361,9 @@ ngx_http_init_connection(ngx_connection_t *c)
+
+         /* We already have a UDP packet in the connection buffer, so we don't
+          * need to wait for another read event to kick-off the handshake. */
+-        ngx_add_timer(rev, c->listening->post_accept_timeout);
++        cscf = ngx_http_get_module_srv_conf(hc->conf_ctx,
++                                            ngx_http_core_module);
++        ngx_add_timer(rev, cscf->client_header_timeout);
+         ngx_http_quic_handshake(rev);
+         return;
+     }
+@@ -1102,6 +1104,7 @@ ngx_http_quic_handshake(ngx_event_t *rev)
+     ngx_http_connection_t     *hc;
+     ngx_http_v3_srv_conf_t    *qscf;
+     ngx_http_ssl_srv_conf_t   *sscf;
++    ngx_http_core_srv_conf_t  *cscf;
+
+     c = rev->data;
+     hc = c->data;
+@@ -1142,7 +1145,9 @@ ngx_http_quic_handshake(ngx_event_t *rev)
+     if (rc == NGX_AGAIN) {
+
+         if (!rev->timer_set) {
+-            ngx_add_timer(rev, c->listening->post_accept_timeout);
++            cscf = ngx_http_get_module_srv_conf(hc->conf_ctx,
++                                                ngx_http_core_module);
++            ngx_add_timer(rev, cscf->client_header_timeout);
+         }
+
+         c->ssl->handler = ngx_http_ssl_handshake_handler;


### PR DESCRIPTION
I found this patch online which makes the build possible even on the newest nginx version.