### PR TITLE
Update brotli to use master branch

### DIFF
--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -212,8 +212,9 @@ case $OPTION in
 		cd /usr/local/src/nginx/modules || exit 1
 		git clone https://github.com/google/ngx_brotli
 		cd ngx_brotli || exit 1
-		git checkout v1.0.0rc
-		git submodule update --init
+		# Use the master branch for now
+		#git checkout v1.0.0rc
+		#git submodule update --init
 	fi
 
 	# More Headers


### PR DESCRIPTION
The project doesn't seem to use tags in Github.
The brotli submodule got an update last year: https://github.com/google/ngx_brotli/commit/9aec15e2aa6feea2113119ba06460af70ab3ea62
I think we are safe to use it.
I think we should let both lines commented out for the small chance to change back.