### PR TITLE
Fix quiche path

### DIFF
--- a/.github/workflows/docker/wrapper.sh
+++ b/.github/workflows/docker/wrapper.sh
@@ -15,7 +15,7 @@ if [[ $INSTALL_TYPE == "FULL" ]]; then
     export VTS=y
     export RTMP=y
     export TESTCOOKIE=y
-    export HTTP3=n # quiche patch is broken for > 1.19.6: https://github.com/cloudflare/quiche/issues/859
+    export HTTP3=y
     export MODSEC=y
     export HPACK=y
     export RTMP=y

--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -518,7 +518,7 @@ case $OPTION in
 
 		cd /usr/local/src/nginx/nginx-${NGINX_VER} || exit 1
 		# Apply actual patch
-		patch -p01 </usr/local/src/nginx/modules/quiche/extras/nginx/nginx-1.16.patch
+		patch -p01 </usr/local/src/nginx/modules/quiche/nginx/nginx-1.16.patch
 
 		# Apply patch for nginx > 1.19.7 (source: https://github.com/cloudflare/quiche/issues/936#issuecomment-857618081)
 		wget https://raw.githubusercontent.com/angristan/nginx-autoinstall/master/patches/nginx-http3-1.19.7.patch -O nginx-http3.patch

--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -526,7 +526,7 @@ case $OPTION in
 
 		NGINX_OPTIONS=$(
 			echo "$NGINX_OPTIONS"
-			echo --with-openssl=/usr/local/src/nginx/modules/quiche/deps/boringssl --with-quiche=/usr/local/src/nginx/modules/quiche
+			echo --with-openssl=/usr/local/src/nginx/modules/quiche/quiche/deps/boringssl --with-quiche=/usr/local/src/nginx/modules/quiche
 		)
 		NGINX_MODULES=$(
 			echo "$NGINX_MODULES"


### PR DESCRIPTION
Since the quiche repository refactor in commit [#bbe6e2a](https://github.com/cloudflare/quiche/commit/bbe6e2ab22126773bb63e4605ac4c8e7594f002a) path for boringssl needs an update. I tested this on my machine with success. 