### PR TITLE
Cache modules

### DIFF
--- a/.github/workflows/docker/wrapper.sh
+++ b/.github/workflows/docker/wrapper.sh
@@ -18,8 +18,11 @@ if [[ $INSTALL_TYPE == "FULL" ]]; then
     export HTTP3=y
     export MODSEC=y
     export HPACK=y
-    export RTMP=y
-    export SUBFILTER=y
+    export REDIS2=y
+    export HTTPREDIS=y
+    export SRCACHE=y
+    export SETMISC=y
+    export NGXECHO=y
 fi
 
 bash -x ../../nginx-autoinstall.sh

--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ The script might work on ARM-based architectures, but it's only being regularly 
 - [RTMP module](https://github.com/arut/nginx-rtmp-module) (NGINX-based Media Streaming Server)
 - [nginx-ultimate-bad-bot-blocker](https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker): Bad Bot and User-Agent Blocker, Spam Referrer Blocker, Anti DDOS, Bad IP Blocker and Wordpress Theme Detector Blocker
 
+#### Cache Modules
+
+- [redis2-nginx-module](https://github.com/openresty/redis2-nginx-module) : Nginx upstream module for the Redis 2.0 protocol
+- [ngx_http_redis](https://www.nginx.com/resources/wiki/modules/redis/) : The nginx HTTP redis module for caching with redis
+- [srcache-nginx-module](https://github.com/openresty/srcache-nginx-module) : Transparent subrequest-based caching layout for arbitrary nginx locations
+- [set-misc-nginx-module](https://github.com/openresty/set-misc-nginx-module) : Various set_xxx directives added to nginx's rewrite module (md5/sha1, sql/json quoting, and many more)
+- [echo-nginx-module](https://github.com/openresty/echo-nginx-module) : Brings "echo", "sleep", "time", "exec" and more shell-style goodies to Nginx config file.
+  - Required to set up [Redis with conditional purging](https://easyengine.io/wordpress-nginx/tutorials/single-site/redis_cache-with-conditional-purging/)
+  - Install Redis with ```apt install redis-{tools,server}```
+
 ## Usage
 
 Just download and execute the script :

--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -43,7 +43,6 @@ if [[ $HEADLESS == "y" ]]; then
 	SRCACHE=${SRCACHE:-n}
 	SETMISC=${SETMISC:-n}
 	HPACK=${HPACK:-n}
-	SUBFILTER=${SUBFILTER:-n}
 	SSL=${SSL:-1}
 	RM_CONF=${RM_CONF:-y}
 	RM_LOGS=${RM_LOGS:-y}

--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -19,6 +19,7 @@ LUA_JIT_VER=2.1-20201229
 LUA_NGINX_VER=0.10.19
 NGINX_DEV_KIT=0.3.1
 HTTPREDIS_VER=0.3.9
+NGXECHO_VER=0.62
 
 # Define installation parameters for headless install (fallback if unspecifed)
 if [[ $HEADLESS == "y" ]]; then
@@ -42,6 +43,7 @@ if [[ $HEADLESS == "y" ]]; then
 	HTTPREDIS=${HTTPREDIS:-n}
 	SRCACHE=${SRCACHE:-n}
 	SETMISC=${SETMISC:-n}
+	NGXECHO=${NGXECHO:-n}
 	HPACK=${HPACK:-n}
 	SSL=${SSL:-1}
 	RM_CONF=${RM_CONF:-y}
@@ -164,6 +166,10 @@ case $OPTION in
 		while [[ $SETMISC != "y" && $SETMISC != "n" ]]; do
 			read -rp "       set-misc-nginx-module [y/n]: " -e -i n SETMISC
 		done
+		while [[ $NGXECHO != "y" && $NGXECHO != "n" ]]; do
+			read -rp "        echo-nginx-module [y/n]: " -e -i n NGXECHO
+		done
+
 		if [[ $HTTP3 != 'y' ]]; then
 			echo ""
 			echo "Choose your OpenSSL implementation:"
@@ -361,6 +367,13 @@ case $OPTION in
 		cd /usr/local/src/nginx/modules || exit 1
 		wget https://github.com/simplresty/ngx_devel_kit/archive/v${NGINX_DEV_KIT}.tar.gz
 		tar xaf v${NGINX_DEV_KIT}.tar.gz
+	fi
+
+	# Download echo-nginx-module
+	if [[ $NGXECHO == 'y' ]]; then
+		cd /usr/local/src/nginx/modules || exit 1
+		wget https://github.com/openresty/echo-nginx-module/archive/refs/tags/v${NGXECHO_VER}.tar.gz
+		tar xaf echo-nginx-module-${NGXECHO_VER}.tar.gz
 	fi
 
 	# Download and extract of Nginx source code
@@ -563,6 +576,13 @@ case $OPTION in
 		NGINX_MODULES=$(
 			echo "$NGINX_MODULES"
 			echo --add-module=/usr/local/src/nginx/modules/set-misc-nginx-module
+		)
+	fi
+
+	if [[ $NGXECHO == 'y' ]]; then
+		NGINX_MODULES=$(
+			echo "$NGINX_MODULES"
+			echo --add-module=/usr/local/src/nginx/modules/echo-nginx-module-${NGXECHO_VER}
 		)
 	fi
 

--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -373,7 +373,7 @@ case $OPTION in
 	if [[ $NGXECHO == 'y' ]]; then
 		cd /usr/local/src/nginx/modules || exit 1
 		wget https://github.com/openresty/echo-nginx-module/archive/refs/tags/v${NGXECHO_VER}.tar.gz
-		tar xaf echo-nginx-module-${NGXECHO_VER}.tar.gz
+		tar xaf v${NGXECHO_VER}.tar.gz
 	fi
 
 	# Download and extract of Nginx source code

--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -554,11 +554,14 @@ case $OPTION in
 
 	if [[ $SETMISC == 'y' ]]; then
 		git clone --depth 1 --quiet https://github.com/openresty/set-misc-nginx-module.git /usr/local/src/nginx/modules/set-misc-nginx-module
+	if [[ $LUA == 'n' ]]; then
 		NGINX_MODULES=$(
 			echo "$NGINX_MODULES"
-			if [[ $LUA == 'n' ]]; then
 				echo --add-module=/usr/local/src/nginx/modules/ngx_devel_kit-${NGINX_DEV_KIT}
-			fi
+		)
+	fi
+		NGINX_MODULES=$(
+			echo "$NGINX_MODULES"
 			echo --add-module=/usr/local/src/nginx/modules/set-misc-nginx-module
 		)
 	fi


### PR DESCRIPTION
- [redis2-nginx-module](https://github.com/openresty/redis2-nginx-module) : Nginx upstream module for the Redis 2.0 protocol
- [ngx_http_redis](https://www.nginx.com/resources/wiki/modules/redis/) : The nginx HTTP redis module for caching with redis
- [srcache-nginx-module](https://github.com/openresty/srcache-nginx-module) : Transparent subrequest-based caching layout for arbitrary nginx locations
- [set-misc-nginx-module](https://github.com/openresty/set-misc-nginx-module) : Various set_xxx directives added to nginx's rewrite module (md5/sha1, sql/json quoting, and many more)
- [echo-nginx-module](https://github.com/openresty/echo-nginx-module) : Brings "echo", "sleep", "time", "exec" and more shell-style goodies to Nginx config file.
  - Required to set up [Redis with conditional purging](https://easyengine.io/wordpress-nginx/tutorials/single-site/redis_cache-with-conditional-purging/)
  - Install Redis with ```apt install redis-{tools,server}```

PS: Removed duplicate ```SUBFILTER=${SUBFILTER:-n}```

Installed with:

```
HEADLESS=y \
NGINX_VER=MAINLINE \
PAGESPEED=y \
BROTLI=y \
HEADERMOD=y \
FANCYINDEX=y \
CACHEPURGE=y \
SUBFILTER=y \
LUA=n \
WEBDAV=y \
VTS=y \
RTMP=y \
TESTCOOKIE=y \
REDIS2=y \
HTTPREDIS=y \
SRCACHE=y \
SETMISC=y \
NGXECHO=y \
./nginx-autoinstall.sh 2>&1 | tee nginx-installer.log
```

NOTE: ```LUA=n```
Had issues with ```LUA=y```

Confirm with: 
```
 $ nginx -V 2>&1 | grep 'srcache-nginx-module\|redis2-nginx-module\|ngx_http_redis\|set-misc-nginx-module\|echo-nginx-module' -o

redis2-nginx-module
ngx_http_redis
srcache-nginx-module
set-misc-nginx-module
echo-nginx-module

```

Tested on Debian 10/11.