### PR TITLE
Nginx lua fix

### DIFF
--- a/.github/workflows/docker/wrapper.sh
+++ b/.github/workflows/docker/wrapper.sh
@@ -10,7 +10,7 @@ if [[ $INSTALL_TYPE == "FULL" ]]; then
     export FANCYINDEX=y
     export CACHEPURGE=y
     export SUBFILTER=y
-    export LUA=n # broken
+    export LUA=y
     export WEBDAV=y
     export VTS=y
     export RTMP=y

--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -420,7 +420,7 @@ case $OPTION in
 	# Optional options
 	if [[ $LUA == 'y' ]]; then
 		NGINX_OPTIONS=$(
-			echo" $NGINX_OPTIONS"
+			echo " $NGINX_OPTIONS"
 			echo --with-ld-opt="-Wl,-rpath,/usr/local/lib/"
 		)
 	fi

--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -15,8 +15,10 @@ NPS_VER=1.13.35.2
 HEADERMOD_VER=0.33
 LIBMAXMINDDB_VER=1.4.3
 GEOIP2_VER=3.3
-LUA_JIT_VER=2.1-20201229
-LUA_NGINX_VER=0.10.19
+LUA_JIT_VER=2.1-20220310
+LUA_NGINX_VER=0.10.21rc2
+LUA_RESTYCORE_VER=0.1.23rc1
+LUA_RESTYLRUCACHE_VER=0.11
 NGINX_DEV_KIT=0.3.1
 HTTPREDIS_VER=0.3.9
 NGXECHO_VER=0.62
@@ -306,6 +308,19 @@ case $OPTION in
 		wget https://github.com/openresty/lua-nginx-module/archive/v${LUA_NGINX_VER}.tar.gz
 		tar xaf v${LUA_NGINX_VER}.tar.gz
 
+		# lua-resty-core download
+		cd /usr/local/src/nginx/modules || exit 1
+		wget https://github.com/openresty/lua-resty-core/archive/v${LUA_RESTYCORE_VER}.tar.gz
+		tar xaf v${LUA_RESTYCORE_VER}.tar.gz
+		cd lua-resty-core-${LUA_RESTYCORE_VER} || exit 1
+		make install PREFIX=/etc/nginx
+
+		# lua-resty-lrucache download
+		cd /usr/local/src/nginx/modules || exit 1
+		wget https://github.com/openresty/lua-resty-lrucache/archive/v${LUA_RESTYLRUCACHE_VER}.tar.gz
+		tar xaf v${LUA_RESTYLRUCACHE_VER}.tar.gz
+		cd lua-resty-lrucache-${LUA_RESTYLRUCACHE_VER} || exit 1
+		make install PREFIX=/etc/nginx
 	fi
 
 	# LibreSSL
@@ -679,7 +694,10 @@ case $OPTION in
 	if [[ ! -d /etc/nginx/conf.d ]]; then
 		mkdir -p /etc/nginx/conf.d
 	fi
-
+	if [[ -d /etc/nginx/conf.d && $LUA == 'y' ]]; then
+		# add necessary `lua_package_path` directive to `nginx.conf`, in the http context
+		echo -e 'lua_package_path "/etc/nginx/lib/lua/?.lua;;";' >/etc/nginx/conf.d/lua_package_path.conf
+	fi
 	# Restart Nginx
 	systemctl restart nginx
 


### PR DESCRIPTION
- Added missing space. Closing #156
- Added lua-resty-core & lua-resty-lrucache.
- Updated lua-nginx & luajit2.

NOTE: 
- This adds necessary `lua_package_path` directive to `nginx.conf`, in the http context.
  - Puts file in `/etc/nginx/conf.d/lua_package_path.conf`
- This adds a `lib` directory to `/etc/nginx` according to [ngx_http_lua_module - install instructions](https://github.com/openresty/lua-nginx-module#installation) for lua-resty-core & lua-resty-lrucache.
- Switches `export LUA=n` to `export LUA=y` in `.github/workflows/docker/wrapper.sh`

Installed with:

```
HEADLESS=y \
NGINX_VER=MAINLINE \
PAGESPEED=y \
BROTLI=y \
HEADERMOD=y \
FANCYINDEX=y \
CACHEPURGE=y \
SUBFILTER=y \
LUA=y \
WEBDAV=y \
VTS=y \
RTMP=y \
TESTCOOKIE=y \
REDIS2=y \
HTTPREDIS=y \
SRCACHE=y \
SETMISC=y \
NGXECHO=y \
./nginx-autoinstall.sh 2>&1 | tee nginx-installer.log

```

Output from nginx -V:
```

nginx version: nginx/1.21.6
built by gcc 10.2.1 20210110 (Debian 10.2.1-6)
built with OpenSSL 1.1.1n  15 Mar 2022
TLS SNI support enabled
configure arguments: --prefix=/etc/nginx --sbin-path=/usr/sbin/nginx --conf-path=/etc/nginx/nginx.conf --error-log-path=/var/log/nginx/error.log --http-log-path=/var/log/nginx/access.log --pid-path=/var/run/nginx.pid --lock-path=/var/run/nginx.lock --http-client-body-temp-path=/var/cache/nginx/client_temp --http-proxy-temp-path=/var/cache/nginx/proxy_temp --http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp --user=nginx --group=nginx --with-cc-opt=-Wno-deprecated-declarations --with-cc-opt=-Wno-ignored-qualifiers --with-ld-opt=-Wl,-rpath,/usr/local/lib/ --with-threads --with-file-aio --with-http_ssl_module --with-http_v2_module --with-http_mp4_module --with-http_auth_request_module --with-http_slice_module --with-http_stub_status_module --with-http_realip_module --with-http_sub_module --add-module=/usr/local/src/nginx/modules/incubator-pagespeed-ngx-1.13.35.2-stable --add-module=/usr/local/src/nginx/modules/ngx_brotli --add-module=/usr/local/src/nginx/modules/headers-more-nginx-module-0.33 --add-module=/usr/local/src/nginx/modules/ngx_cache_purge --add-module=/usr/local/src/nginx/modules/ngx_http_substitutions_filter_module --add-module=/usr/local/src/nginx/modules/ngx_devel_kit-0.3.1 --add-module=/usr/local/src/nginx/modules/lua-nginx-module-0.10.21rc2 --add-module=/usr/local/src/nginx/modules/fancyindex --with-http_dav_module --add-module=/usr/local/src/nginx/modules/nginx-dav-ext-module --add-module=/usr/local/src/nginx/modules/nginx-module-vts --add-module=/usr/local/src/nginx/modules/nginx-rtmp-module --add-module=/usr/local/src/nginx/modules/testcookie-nginx-module --add-module=/usr/local/src/nginx/modules/redis2-nginx-module --add-module=/usr/local/src/nginx/modules/ngx_http_redis-0.3.9 --add-module=/usr/local/src/nginx/modules/srcache-nginx-module --add-module=/usr/local/src/nginx/modules/set-misc-nginx-module --add-module=/usr/local/src/nginx/modules/echo-nginx-module-0.62

```


Install log: [nginx-installer.log](https://github.com/angristan/nginx-autoinstall/files/8452592/nginx-installer.log)
