### PR TITLE
nginx-1.23.0 mainline version has been released & Bugfix ngx_headers_…

### DIFF
--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -7,7 +7,7 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 # Define versions
-NGINX_MAINLINE_VER=${NGINX_MAINLINE_VER:-1.21.6}
+NGINX_MAINLINE_VER=${NGINX_MAINLINE_VER:-1.23.0}
 NGINX_STABLE_VER=${NGINX_STABLE_VER:-1.22.0}
 LIBRESSL_VER=${LIBRESSL_VER:-3.3.1}
 OPENSSL_VER=${OPENSSL_VER:-1.1.1l}
@@ -288,8 +288,7 @@ case $OPTION in
 	# More Headers
 	if [[ $HEADERMOD == 'y' ]]; then
 		cd /usr/local/src/nginx/modules || exit 1
-		wget https://github.com/openresty/headers-more-nginx-module/archive/v${HEADERMOD_VER}.tar.gz
-		tar xaf v${HEADERMOD_VER}.tar.gz
+		git clone https://github.com/openresty/headers-more-nginx-module
 	fi
 
 	# GeoIP
@@ -523,7 +522,7 @@ case $OPTION in
 	if [[ $HEADERMOD == 'y' ]]; then
 		NGINX_MODULES=$(
 			echo "$NGINX_MODULES"
-			echo "--add-module=/usr/local/src/nginx/modules/headers-more-nginx-module-${HEADERMOD_VER}"
+			echo "--add-module=/usr/local/src/nginx/modules/headers-more-nginx-module"
 		)
 	fi
 


### PR DESCRIPTION
Changes with nginx 1.23.0                                        21 Jun 2022

    *) Change in internal API: now header lines are represented as linked
       lists.

    *) Change: now nginx combines arbitrary header lines with identical
       names when sending to FastCGI, SCGI, and uwsgi backends, in the
       $r->header_in() method of the ngx_http_perl_module, and during lookup
       of the "$http_...", "$sent_http_...", "$sent_trailer_...",
       "$upstream_http_...", and "$upstream_trailer_..." variables.

    *) Bugfix: if there were multiple "Vary" header lines in the backend
       response, nginx only used the last of them when caching.

    *) Bugfix: if there were multiple "WWW-Authenticate" header lines in the
       backend response and errors with code 401 were intercepted or the
       "auth_request" directive was used, nginx only sent the first of the
       header lines to the client.

    *) Change: the logging level of the "application data after close
       notify" SSL errors has been lowered from "crit" to "info".

    *) Bugfix: connections might hang if nginx was built on Linux 2.6.17 or
       newer, but was used on systems without EPOLLRDHUP support, notably
       with epoll emulation layers; the bug had appeared in 1.17.5.
       Thanks to Marcus Ball.

    *) Bugfix: nginx did not cache the response if the "Expires" response
       header line disabled caching, but following "Cache-Control" header
       line enabled caching.

Bugfix ngx_headers_more :

https://github.com/openresty/headers-more-nginx-module/commit/91eb0db9ef9ac05c4c514b8f1fdf8a8170cc354e

I edited the file in my browser, I know that HEADERMOD_VER is now unused. I was unsure, If I should have apply the bugfix only, but since the last release of this module is 2017, I consider that this is fine with the current context.

Compilation is now working properly on my side.
nginx -V
nginx version: nginx/1.22.0
built by gcc 10.2.1 20210110 (Debian 10.2.1-6) 
built with OpenSSL 1.1.1n  15 Mar 2022
TLS SNI support enabled
configure arguments: --prefix=/etc/nginx --sbin-path=/usr/sbin/nginx --conf-path=/etc/nginx/nginx.conf --error-log-path=/var/log/nginx/error.log --http-log-path=/var/log/nginx/access.log --pid-path=/var/run/nginx.pid --lock-path=/var/run/nginx.lock --http-client-body-temp-path=/var/cache/nginx/client_temp --http-proxy-temp-path=/var/cache/nginx/proxy_temp --http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp --user=nginx --group=nginx --with-cc-opt=-Wno-deprecated-declarations --with-cc-opt=-Wno-ignored-qualifiers --with-threads --with-file-aio --with-http_ssl_module --with-http_v2_module --with-http_mp4_module --with-http_auth_request_module --with-http_slice_module --with-http_stub_status_module --with-http_realip_module --with-http_sub_module --add-module=/usr/local/src/nginx/modules/ngx_brotli --add-module=/usr/local/src/nginx/modules/headers-more-nginx-module

However, before this was not the case unfortunately.