### PR TITLE
Take headless as script argument

### DIFF
--- a/nginx-autoinstall.sh
+++ b/nginx-autoinstall.sh
@@ -6,6 +6,11 @@ if [[ $EUID -ne 0 ]]; then
 	exit 1
 fi
 
+# Take headless as script argument
+if [[ $1 == "headless" ]]; then
+	HEADLESS=y
+fi
+
 # Define versions
 NGINX_MAINLINE_VER=${NGINX_MAINLINE_VER:-1.21.6}
 NGINX_STABLE_VER=${NGINX_STABLE_VER:-1.22.0}


### PR DESCRIPTION
Had difficulty using HEADLESS=y arguments when sourcing the script directly

Now you can use with curl
```bash
curl -sSL $NGINX_AUTOINSTALL_URL | bash -s headless
```
or wget
```bash
wget -qO- $NGINX_AUTOINSTALL_URL | bash -s headless
```